### PR TITLE
Allow pull of raw files from spring cloud config

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -15,7 +15,7 @@ const (
 
 type ConfigClient interface {
 	GetConfig(attributes Attributes) (io.ReadCloser, error)
-	GetConfigRaw(attributes Attributes, idx int) (io.ReadCloser, error)
+	GetConfigRaw(attributes Attributes, source string) (io.ReadCloser, error)
 }
 
 type SpringCloudConfigClient struct {
@@ -45,8 +45,8 @@ func (c *SpringCloudConfigClient) GetConfig(attributes Attributes) (io.ReadClose
 }
 
 // GetConfigRaw pulls the config from spring-cloud-config without parsing or decrypting the secrets
-func (c *SpringCloudConfigClient) GetConfigRaw(attributes Attributes, idx int) (io.ReadCloser, error) {
-	fullAddress := attributes.ServerAddress + springRawGetConfigPath + attributes.Application + "/" + attributes.Profile + "/" + defaultConfigBranch + "/" + attributes.Raw[idx].Source
+func (c *SpringCloudConfigClient) GetConfigRaw(attributes Attributes, source string) (io.ReadCloser, error) {
+	fullAddress := attributes.ServerAddress + springRawGetConfigPath + attributes.Application + "/" + attributes.Profile + "/" + defaultConfigBranch + "/" + source
 	r, err := c.client.Get(fullAddress)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Currently, only the pull of yaml and json files is possible even though spring cloud config offers a `Raw` pull as well.
This PR adds the provider functionality for this. A list of `Raw` files can be defined in the Resource for the same config repository.