### PR TITLE
Release Docker image for architecture "arm64"

### DIFF
--- a/.github/buildkit.toml
+++ b/.github/buildkit.toml
@@ -1,0 +1,2 @@
+[worker.oci]
+max-parallelism = 2

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -15,5 +15,12 @@ jobs:
     - uses: actions/checkout@v1
     - name: Login to Docker Hub
       run: docker login --username platformbuild --password ${{ secrets.DOCKER_HUB_PASS }}
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        config: .github/buildkit.toml
     - name: Build and Push the Docker image
       run: env BUILD_BRANCH=${GITHUB_REF##*/} make release_latest

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,5 @@ release: test package
 .PHONY: release_latest
 release_latest: release
 ifeq (${BUILD_BRANCH},master)
-	docker tag ${CONTAINER_IMAGE} ${REGISTRY}/${PROJECT_NAME}:latest
-	docker push ${REGISTRY}/${PROJECT_NAME}:latest
+	docker buildx build --push --platform linux/amd64,linux/arm64 -t ${CONTAINER_IMAGE} ${REGISTRY}/${PROJECT_NAME}:latest
 endif

--- a/Makefile
+++ b/Makefile
@@ -20,18 +20,18 @@ build: setup
 
 .PHONY: package
 package:
-	docker build --rm --pull -t ${CONTAINER_IMAGE} .
+	docker buildx build --platform linux/amd64,linux/arm64 -t ${CONTAINER_IMAGE} .
 
 .PHONY: test
 test:
 	docker run --rm -e CGO_ENABLED=0 -v "$(PWD):/go/src/github.com/freenowtech/$(PROJECT_NAME)" -w "/go/src/github.com/freenowtech/$(PROJECT_NAME)" golang:1.13.4-alpine  go test ./...
 
 .PHONY: release
-release: test package
-	docker push ${CONTAINER_IMAGE}
+release: test
+	docker buildx build --push --platform linux/amd64,linux/arm64 -t ${CONTAINER_IMAGE} .
 
 .PHONY: release_latest
-release_latest: release
+release_latest: test
 ifeq (${BUILD_BRANCH},master)
-	docker buildx build --push --platform linux/amd64,linux/arm64 -t ${CONTAINER_IMAGE} ${REGISTRY}/${PROJECT_NAME}:latest
+	docker buildx build --push --platform linux/amd64,linux/arm64 -t ${REGISTRY}/${PROJECT_NAME}:latest .
 endif


### PR DESCRIPTION
This change sets up the build process to release Docker images for architectures "amd64" and "arm64".

It configures QEMU + buildx and modifies the Makefile to use `docker buildx`.