### PR TITLE
Add local testing section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 secrets-store-csi-driver-provider-spring-cloud-config
 =====================================================
 
-The Spring Cloud Config provider for Secrets Store CSI driver allows you to get content stored in Spring Cloud Config
+The Spring Cloud Config provider
+for [Secrets Store CSI driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver) allows you to get content
+stored in Spring Cloud Config
 and use the Secrets Store CSI driver interface to mount them into a Kubernetes pods.
 
 Usage
@@ -9,17 +11,8 @@ Usage
 
 ### Install the Secrets Store CSI Driver
 
----
-
-**NOTE**
-
-To install the Secrets Store CSI driver you need Kubernetes 1.15.x with the CSIInlineVolume feature gate or a 1.16.x+
-cluster.
-
----
-
 Make sure you have followed the Installation guide for
-the [Secrets Store CSI Driver](https://github.com/deislabs/secrets-store-csi-driver#usage).
+the [Secrets Store CSI Driver](https://secrets-store-csi-driver.sigs.k8s.io/getting-started/installation.html).
 
 Create a `SecretProviderClass` resource to provide Spring-Cloud-Config-specific parameters for the Secrets Store CSI
 driver.
@@ -66,6 +59,8 @@ spec:
 Development
 -----
 
+### Local Testing
+
 To test the secrets store, a local kubernetes should be created for example via minikube.
 After cluster startup you can install the secrets-store-csi-driver and add the spring cloud config secret provider.
 
@@ -85,4 +80,6 @@ kubectl logs <secrets-store-registrator-pod> # to verify whether the new provide
 
 Now a new `SecretProviderClass` resource should be created to test whether both the secrets-store and the provider work
 as expected
-You can use the example from the [installation](#Install the Secrets Store CSI Driver). 
+You can use the example from the [installation](#Install the Secrets Store CSI Driver).
+If everything went as expected the secret file should exist inside the pod.
+If not, the secrets-store logs should be checked.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 secrets-store-csi-driver-provider-spring-cloud-config
 =====================================================
 
-The Spring Cloud Config provider for Secrets Store CSI driver allows you to get content stored in Spring Cloud Config and use the Secrets Store CSI driver interface to mount them into a Kubernetes pods.
+The Spring Cloud Config provider for Secrets Store CSI driver allows you to get content stored in Spring Cloud Config
+and use the Secrets Store CSI driver interface to mount them into a Kubernetes pods.
 
 Usage
 -----
@@ -12,13 +13,16 @@ Usage
 
 **NOTE**
 
-To install the Secrets Store CSI driver you need Kubernetes 1.15.x with the CSIInlineVolume feature gate or a 1.16.x+ cluster.
+To install the Secrets Store CSI driver you need Kubernetes 1.15.x with the CSIInlineVolume feature gate or a 1.16.x+
+cluster.
 
 ---
 
-Make sure you have followed the Installation guide for the [Secrets Store CSI Driver](https://github.com/deislabs/secrets-store-csi-driver#usage).
+Make sure you have followed the Installation guide for
+the [Secrets Store CSI Driver](https://github.com/deislabs/secrets-store-csi-driver#usage).
 
-Create a `SecretProviderClass` resource to provide Spring-Cloud-Config-specific parameters for the Secrets Store CSI driver.
+Create a `SecretProviderClass` resource to provide Spring-Cloud-Config-specific parameters for the Secrets Store CSI
+driver.
 
 ```yaml
 apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
@@ -32,7 +36,7 @@ spec:
     application: "<your-application>" # the application you're retrieving the config for
     profile: "<your-profile>" # the profile for your application to pull
     fileType: "json" # json or properties viable
-    
+
 ```
 
 Afterwards you can reference your `SecretProviderClass` in your Pod Definition
@@ -44,12 +48,12 @@ metadata:
   name: nginx-secrets-store-inline
 spec:
   containers:
-  - image: nginx
-    name: nginx
-    volumeMounts:
-    - name: secrets-store-inline
-      mountPath: "/secrets-store"
-      readOnly: true
+    - image: nginx
+      name: nginx
+      volumeMounts:
+        - name: secrets-store-inline
+          mountPath: "/secrets-store"
+          readOnly: true
   volumes:
     - name: secrets-store-inline
       csi:
@@ -58,3 +62,27 @@ spec:
         volumeAttributes:
           secretProviderClass: "spring-cloud-config-<your-application>"
 ```
+
+Development
+-----
+
+To test the secrets store, a local kubernetes should be created for example via minikube.
+After cluster startup you can install the secrets-store-csi-driver and add the spring cloud config secret provider.
+
+```shell
+minikube start --kubernetes-version=<cluster-version>
+cd <path-to-secrets-store-csi-driver-repo>
+kustomize build <kustomize-dir> | kubectl apply --validate=true -f -
+```
+
+Afterwards the new image needs to be build, replacing the currently running provider.
+
+```shell
+make package
+kubectl edit <secrets-store-provider-daemonset> 
+kubectl logs <secrets-store-registrator-pod> # to verify whether the new provider was rolled out and registered
+```
+
+Now a new `SecretProviderClass` resource should be created to test whether both the secrets-store and the provider work
+as expected
+You can use the example from the [installation](#Install the Secrets Store CSI Driver). 


### PR DESCRIPTION
To be able to do local integration tests between the secrets-store and provider, a section should be added in the README. The section should include the test preparation as well as a basic test.

Please check for any missing context or implicit knowledge which should be described better. As well as general structural improvements to the docs. 