### PR TITLE
Use Actions to execute tests

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,0 +1,24 @@
+name: Go
+
+on:
+  pull_request: {}
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version:
+          - '1.22.x'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+      # You can test your matrix by printing the current Go version
+      - name: Run tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ package:
 
 .PHONY: test
 test:
-	docker run --rm -e CGO_ENABLED=0 -v "$(PWD):/go/src/github.com/freenowtech/$(PROJECT_NAME)" -w "/go/src/github.com/freenowtech/$(PROJECT_NAME)" golang:1.13.4-alpine  go test ./...
+	go test ./...
 
 .PHONY: release
 release: test


### PR DESCRIPTION
Previously, tests were running in Docker.

This change uses GitHub Actions to execute the tests.