### PR TITLE
Fix unmarshal error when no raw files are defined

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/freenowtech/secrets-store-csi-driver-provider-spring-cloud-con
 go 1.22.1
 
 require (
+	github.com/h2non/gock v1.2.0
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.8.2
 	google.golang.org/grpc v1.56.3
@@ -12,6 +13,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,12 @@ github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/h2non/gock v1.2.0 h1:K6ol8rfrRkUOefooBC8elXoaNGYkpp7y2qcxGG6BzUE=
+github.com/h2non/gock v1.2.0/go.mod h1:tNhoxHYW2W42cYkYb1WqzdbYIieALC99kpYr7rH/BQk=
+github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslCrtky5vbi9dd7HrQPQIx6wqiw=
+github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ func main() {
 	// Delete previous socket if exists
 	_ = os.Remove(socketPath)
 
-	server, err := provider.NewSpringCloudConfigCSIProviderServer(socketPath)
+	server, err := provider.NewSpringCloudConfigCSIProviderServer(socketPath, nil)
 	if err != nil {
 		log.Fatalf("error occured on server initialization: %v", err)
 	}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -19,14 +19,18 @@ type ConfigClient interface {
 }
 
 type SpringCloudConfigClient struct {
-	client http.Client
+	client *http.Client
 }
 
-func NewSpringCloudConfigClient() SpringCloudConfigClient {
-	return SpringCloudConfigClient{
-		client: http.Client{
+func NewSpringCloudConfigClient(c *http.Client) SpringCloudConfigClient {
+	if c == nil {
+		c = &http.Client{
 			Timeout: 5 * time.Second,
-		},
+		}
+	}
+
+	return SpringCloudConfigClient{
+		client: c,
 	}
 }
 

--- a/pkg/provider/server_test.go
+++ b/pkg/provider/server_test.go
@@ -4,112 +4,113 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
-	"io/ioutil"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"testing"
 
+	"github.com/h2non/gock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/secrets-store-csi-driver/provider/v1alpha1"
 )
 
-type configClientMock struct {
-	configResult string
-	err          error
-}
-
-func (c *configClientMock) GetConfig(_ Attributes) (io.ReadCloser, error) {
-	if c.err != nil {
-		return nil, c.err
+func TestSpringCloudConfigCSIProviderServer_Mount(t *testing.T) {
+	type configServerRequest struct {
+		path            string
+		statusCode      int
+		responsePayload string
 	}
-	return io.NopCloser(strings.NewReader(c.configResult)), nil
-}
 
-func (c *configClientMock) GetConfigRaw(_ Attributes, _ string) (io.ReadCloser, error) {
-	if c.err != nil {
-		return nil, c.err
-	}
-	return io.NopCloser(strings.NewReader(c.configResult)), nil
-}
-
-func newConfigClientMock(expected string, err error) configClientMock {
-	return configClientMock{
-		configResult: expected,
-		err:          err,
-	}
-}
-
-func TestMountSecretsStoreObjectContent(t *testing.T) {
 	testcases := []struct {
-		name          string
-		attrib        Attributes
-		expected      string
-		expectedRaw   []string
-		expectedError error
-		clientError   error
+		name                 string
+		configServerRequests []*configServerRequest
+		attrib               Attributes
+		wantFiles            map[string]string
+		expected             string
+		wantRawContent       map[string]string
+		wantError            error
 	}{
 		{
-			name: "When all attributes are passed and correct then it creates the secret file",
+			name: "When all attributes are passed and correctly then it creates the secret file",
+			configServerRequests: []*configServerRequest{
+				{
+					path:            "/config/some/testing.json",
+					statusCode:      200,
+					responsePayload: `{"some":"json"}`,
+				},
+			},
 			attrib: Attributes{
-				ServerAddress: "http://example.com/",
+				ServerAddress: "http://configserver.localhost",
 				Profile:       "testing",
 				Application:   "some",
 				FileType:      "json",
 			},
-			expected: "{\"some\":\"json\"}",
+			wantFiles: map[string]string{"some-testing.json": `{"some":"json"}`},
+		},
+		{
+			name: "When raw files are part of the attributes then it creates the raw files",
+			configServerRequests: []*configServerRequest{
+				{
+					path:            "/springconfig/some/testing/master/abc.conf",
+					statusCode:      200,
+					responsePayload: "content abc.def",
+				},
+			},
+			attrib: Attributes{
+				ServerAddress: "http://configserver.localhost",
+				Profile:       "testing",
+				Application:   "some",
+				Raw:           `[{"source":"abc.conf","target":"def.conf"}]`,
+			},
+			wantFiles: map[string]string{"def.conf": "content abc.def"},
 		},
 		{
 			name: "When an attribute is not set then an error is returned",
 			attrib: Attributes{
-				ServerAddress: "http://example.com/",
+				ServerAddress: "http://configserver.localhost",
 				Profile:       "testing",
 				Application:   "some",
 			},
-			expectedError: errors.New("FileType and raw are not set, atleast one is required"),
+			wantError: errors.New("FileType and raw are not set, atleast one is required"),
 		},
 		{
-			name: "When the ServerAddress is wrong then an error is returned",
+			name: "When ConfigServer returns an error then it errors",
+			configServerRequests: []*configServerRequest{
+				{path: "/config/some/testing.json",
+					statusCode:      500,
+					responsePayload: "an error occurred",
+				},
+			},
 			attrib: Attributes{
-				ServerAddress: "example.com/",
+				ServerAddress: "http://configserver.localhost",
 				Profile:       "testing",
 				Application:   "some",
 				FileType:      "json",
 			},
-			expectedError: errors.New("failed to retrieve secrets for some-testing.json: some error"),
-			clientError:   errors.New("some error"),
+			wantError: errors.New("failed to retrieve secrets for some-testing.json: received 500 instead of 200 while calling http://configserver.localhost/config/some/testing.json"),
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			defer gock.Off()
+			//gock.Observe(gock.DumpRequest)
+			for _, mockRequest := range tc.configServerRequests {
+				gock.New(tc.attrib.ServerAddress).
+					Get(mockRequest.path).
+					Reply(mockRequest.statusCode).
+					BodyString(mockRequest.responsePayload)
+			}
+
 			dir, err := os.MkdirTemp("", "scc-secrets-store-unittest")
 			if err != nil {
 				t.Fatal(err)
 			}
-			file := path.Join(dir, "some-testing.json")
-			sccMock := newConfigClientMock(tc.expected, tc.clientError)
-			// forcing test raw targets to create the files in the temp dir
-			var raw []Raw
-			if tc.attrib.Raw != "" {
-				raw, err = tc.attrib.getRaw()
-				if err != nil {
-					t.Fatal(err)
-				}
-			}
-			for idx, item := range raw {
-				raw[idx].Target = path.Join(dir, item.Target)
-			}
-			rawBytes, err := json.Marshal(raw)
-			if err != nil {
-				t.Fatal(err)
-			}
-			tc.attrib.Raw = string(rawBytes)
 
-			provider, _ := NewSpringCloudConfigCSIProviderServer(filepath.Join(dir, "scc.sock"))
-			provider.springCloudConfigClient = &sccMock
+			httpClient := createHttpClient()
+			provider, _ := NewSpringCloudConfigCSIProviderServer(filepath.Join(dir, "scc.sock"), httpClient)
 
 			attributes, err := json.Marshal(tc.attrib)
 			if err != nil {
@@ -127,25 +128,33 @@ func TestMountSecretsStoreObjectContent(t *testing.T) {
 				t.Fatal(resp.Error.String())
 			}
 
-			if tc.expectedError != nil {
-				assert.EqualError(t, err, tc.expectedError.Error(), tc.name)
+			if tc.wantError != nil {
+				assert.EqualError(t, err, tc.wantError.Error(), tc.name)
 			} else {
-				assert.NoError(t, err, tc.name)
-				actual, err := ioutil.ReadFile(file)
-				if err != nil {
-					t.Fatal(err)
-				}
-				assert.Equal(t, tc.expected, string(actual), tc.name)
-
-				for idx, item := range tc.expectedRaw {
-					file, err := ioutil.ReadFile(raw[idx].Target)
-					if err != nil {
-						t.Fatal(err)
+				assert.NoError(t, err)
+				entries, err := os.ReadDir(dir)
+				require.NoError(t, err)
+				actualFiles := map[string]string{}
+				for _, entry := range entries {
+					if entry.IsDir() {
+						continue
 					}
-					assert.Equal(t, item, string(file), tc.name)
+
+					content, err := os.ReadFile(path.Join(dir, entry.Name()))
+					require.NoError(t, err)
+					actualFiles[entry.Name()] = string(content)
 				}
+
+				assert.Equal(t, tc.wantFiles, actualFiles)
 			}
+
+			require.True(t, gock.IsDone())
 		})
 	}
+}
 
+func createHttpClient() *http.Client {
+	c := &http.Client{}
+	gock.InterceptClient(c)
+	return c
 }


### PR DESCRIPTION
When the attribute `Raw` is unset, the provider fails with the error message
```
unexpected end of JSON input
```
when it tries to mount a configuration file.

This change fixes the issue by adding a guard that checks if raw files have been set.

Also rewrites tests to cover more code branches.