### PR TITLE
Retry requests to Config Server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22.1
 
 require (
 	github.com/h2non/gock v1.2.0
+	github.com/sethvargo/go-retry v0.2.4
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.8.2
 	google.golang.org/grpc v1.56.3

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sethvargo/go-retry v0.2.4 h1:T+jHEQy/zKJf5s95UkguisicE0zuF9y7+/vgz08Ocec=
+github.com/sethvargo/go-retry v0.2.4/go.mod h1:1afjQuvh7s4gflMObvjLPaWgluLLyhA1wmVZ6KLpICw=
 github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/main.go
+++ b/main.go
@@ -1,22 +1,29 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/freenowtech/secrets-store-csi-driver-provider-spring-cloud-config/pkg/provider"
 	log "github.com/sirupsen/logrus"
 )
 
 func main() {
+	var retryBaseWait time.Duration
+	var retryMax int64
+	flag.DurationVar(&retryBaseWait, "retry-base-wait", 1*time.Second, "Duration to wait for the exponential retry algorithm before retrying a request to Config Server.")
+	flag.Int64Var(&retryMax, "retry-max", 0, "Max number of retries in case Config Server responds with an error. 0 disables retries.")
+	flag.Parse()
 	socketPath := filepath.Join(os.Getenv("TARGET_DIR"), "spring-cloud-config.sock")
 	// Delete previous socket if exists
 	_ = os.Remove(socketPath)
 
-	server, err := provider.NewSpringCloudConfigCSIProviderServer(socketPath, nil)
+	server, err := provider.NewSpringCloudConfigCSIProviderServer(socketPath, nil, retryBaseWait, uint64(retryMax))
 	if err != nil {
 		log.Fatalf("error occured on server initialization: %v", err)
 	}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1,10 +1,13 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/sethvargo/go-retry"
 )
 
 const (
@@ -19,18 +22,26 @@ type ConfigClient interface {
 }
 
 type SpringCloudConfigClient struct {
-	client *http.Client
+	backoff retry.Backoff
+	client  *http.Client
 }
 
-func NewSpringCloudConfigClient(c *http.Client) SpringCloudConfigClient {
+func NewSpringCloudConfigClient(c *http.Client, retryBaseWait time.Duration, retryMax uint64) SpringCloudConfigClient {
 	if c == nil {
 		c = &http.Client{
 			Timeout: 5 * time.Second,
 		}
 	}
 
+	var b retry.Backoff
+	if retryMax != 0 {
+		b = retry.NewExponential(retryBaseWait)
+		b = retry.WithMaxRetries(retryMax, b)
+	}
+
 	return SpringCloudConfigClient{
-		client: c,
+		backoff: b,
+		client:  c,
 	}
 }
 
@@ -38,7 +49,12 @@ func NewSpringCloudConfigClient(c *http.Client) SpringCloudConfigClient {
 // if the config contains secrets they are decoded on the server side
 func (c *SpringCloudConfigClient) GetConfig(attributes Attributes) (io.ReadCloser, error) {
 	fullAddress := attributes.ServerAddress + springGetConfigPath + attributes.Application + "/" + attributes.Profile + "." + attributes.FileType
-	r, err := c.client.Get(fullAddress)
+	req, err := http.NewRequest("GET", fullAddress, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create new GetConfig request: %w", err)
+	}
+
+	r, err := c.do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +67,12 @@ func (c *SpringCloudConfigClient) GetConfig(attributes Attributes) (io.ReadClose
 // GetConfigRaw pulls the config from spring-cloud-config without parsing or decrypting the secrets
 func (c *SpringCloudConfigClient) GetConfigRaw(attributes Attributes, source string) (io.ReadCloser, error) {
 	fullAddress := attributes.ServerAddress + springRawGetConfigPath + attributes.Application + "/" + attributes.Profile + "/" + defaultConfigBranch + "/" + source
-	r, err := c.client.Get(fullAddress)
+	req, err := http.NewRequest("GET", fullAddress, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create new GetConfigRaw request: %w", err)
+	}
+
+	r, err := c.do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -60,4 +81,27 @@ func (c *SpringCloudConfigClient) GetConfigRaw(attributes Attributes, source str
 	}
 	return r.Body, nil
 
+}
+
+func (c *SpringCloudConfigClient) do(req *http.Request) (*http.Response, error) {
+	if c.backoff == nil {
+		return c.client.Do(req)
+	}
+
+	var resp *http.Response
+	err := retry.Do(context.Background(), c.backoff, func(ctx context.Context) error {
+		var doErr error
+		resp, doErr = c.client.Do(req)
+		if doErr != nil {
+			return retry.RetryableError(doErr)
+		}
+
+		if resp != nil && resp.StatusCode >= 500 {
+			return retry.RetryableError(fmt.Errorf("request failed with status code %d", resp.StatusCode))
+		}
+
+		return nil
+	})
+
+	return resp, err
 }

--- a/pkg/provider/server.go
+++ b/pkg/provider/server.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -86,8 +87,8 @@ func (a *Attributes) verify() (err error) {
 }
 
 // NewSpringCloudConfigCSIProviderServer returns CSI provider that uses the spring as the secret backend
-func NewSpringCloudConfigCSIProviderServer(socketPath string, httpClient *http.Client) (*SpringCloudConfigCSIProviderServer, error) {
-	client := NewSpringCloudConfigClient(httpClient)
+func NewSpringCloudConfigCSIProviderServer(socketPath string, httpClient *http.Client, retryBaseWait time.Duration, retryMax uint64) (*SpringCloudConfigCSIProviderServer, error) {
+	client := NewSpringCloudConfigClient(httpClient, retryBaseWait, retryMax)
 	server := grpc.NewServer()
 	s := &SpringCloudConfigCSIProviderServer{
 		springCloudConfigClient: &client,


### PR DESCRIPTION
Basic guard against temporary unavailability of Config Server.

- Add retry logic to the client that calls Config Server.
- Add flags to configure retry behavior.