### PR TITLE
feature: Add attribute fileName

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ Create a `SecretProviderClass` resource to provide Spring-Cloud-Config-specific 
 apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
 kind: SecretProviderClass
 metadata:
-  name: spring-cloud-config-<your-application>
+  name: spring-cloud-config-example
 spec:
   provider: spring-cloud-config
   parameters:
-    serverAddress: "<your-server-address>" # this url should point config server
-    application: "<your-application>" # the application you're retrieving the config for
-    profile: "<your-profile>" # the profile for your application to pull
-    fileName: "application.yaml"
+    serverAddress: "http://configserver.example" # this url should point to config server
+    application: "myapp" # the application you're retrieving the config for
+    profile: "prod" # the profile for your application to pull
+    fileName: "application.yaml" # the name of the file to create
 ```
 
 Afterwards you can reference your `SecretProviderClass` in your Pod Definition
@@ -41,11 +41,15 @@ Afterwards you can reference your `SecretProviderClass` in your Pod Definition
 kind: Pod
 apiVersion: v1
 metadata:
-  name: nginx-secrets-store-inline
+  name: secrets-store-example
 spec:
   containers:
-  - image: nginx
-    name: nginx
+  - image: ubuntu:latest
+    name: ubuntu
+    command: ["/bin/bash"]
+    args:
+      - "-c"
+      - "cat /secrets-store/application.yaml && sleep 300"
     volumeMounts:
     - name: secrets-store-inline
       mountPath: "/secrets-store"
@@ -56,5 +60,5 @@ spec:
         driver: secrets-store.csi.k8s.com
         readOnly: true
         volumeAttributes:
-          secretProviderClass: "spring-cloud-config-<your-application>"
+          secretProviderClass: "spring-cloud-config-example"
 ```

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ spec:
     serverAddress: "<your-server-address>" # this url should point config server
     application: "<your-application>" # the application you're retrieving the config for
     profile: "<your-profile>" # the profile for your application to pull
-    fileType: "json" # json or properties viable
-    
+    fileName: "application.yaml"
 ```
 
 Afterwards you can reference your `SecretProviderClass` in your Pod Definition

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ spec:
     serverAddress: "http://configserver.example" # this url should point to config server
     application: "myapp" # the application you're retrieving the config for
     profile: "prod" # the profile for your application to pull
-    fileName: "application.yaml" # the name of the file to create
+    fileName: "application.yaml" # the name of the file to create - supports extensions .yaml, .yml, .json and .properties
 ```
 
 Afterwards you can reference your `SecretProviderClass` in your Pod Definition

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -48,7 +48,7 @@ func NewSpringCloudConfigClient(c *http.Client, retryBaseWait time.Duration, ret
 // GetConfig pulls the config from spring-cloud config server and the server parses it to the specified format
 // if the config contains secrets they are decoded on the server side
 func (c *SpringCloudConfigClient) GetConfig(attributes Attributes) (io.ReadCloser, error) {
-	fullAddress := attributes.ServerAddress + springGetConfigPath + attributes.Application + "/" + attributes.Profile + "." + attributes.FileType
+	fullAddress := attributes.ServerAddress + springGetConfigPath + attributes.Application + "/" + attributes.Profile + attributes.extension()
 	req, err := http.NewRequest("GET", fullAddress, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create new GetConfig request: %w", err)

--- a/pkg/provider/server_test.go
+++ b/pkg/provider/server_test.go
@@ -51,6 +51,33 @@ func TestSpringCloudConfigCSIProviderServer_Mount(t *testing.T) {
 			wantFiles: map[string]string{"some-testing.json": `{"some":"json"}`},
 		},
 		{
+			name: "When attribute `FileName` is set then it uses the attribute to create the file",
+			configServerRequests: []*configServerRequest{
+				{
+					path:            "/config/some/testing.json",
+					statusCode:      200,
+					responsePayload: `{"some":"json"}`,
+				},
+			},
+			attrib: Attributes{
+				ServerAddress: "http://configserver.localhost",
+				Profile:       "testing",
+				Application:   "some",
+				FileName:      "config.json",
+			},
+			wantFiles: map[string]string{"config.json": `{"some":"json"}`},
+		},
+		{
+			name: "When attribute `FileName` defines an unsupported extension then it errors",
+			attrib: Attributes{
+				ServerAddress: "http://configserver.localhost",
+				Profile:       "testing",
+				Application:   "some",
+				FileName:      "config.toml",
+			},
+			wantError: errors.New("fileName config.toml uses an unsupported extension - supported extensions are .json,.properties,.yaml,.yml"),
+		},
+		{
 			name: "When raw files are part of the attributes then it creates the raw files",
 			configServerRequests: []*configServerRequest{
 				{
@@ -74,7 +101,7 @@ func TestSpringCloudConfigCSIProviderServer_Mount(t *testing.T) {
 				Profile:       "testing",
 				Application:   "some",
 			},
-			wantError: errors.New("FileType and raw are not set, atleast one is required"),
+			wantError: errors.New("attributes fileName, fileType or raw are not set, at least one is required"),
 		},
 		{
 			name: "When ConfigServer returns an error then it errors",

--- a/pkg/provider/server_test.go
+++ b/pkg/provider/server_test.go
@@ -68,6 +68,24 @@ func TestSpringCloudConfigCSIProviderServer_Mount(t *testing.T) {
 			wantFiles: map[string]string{"config.json": `{"some":"json"}`},
 		},
 		{
+			name: "When both attributes `FileName` and `FileType` are set then attribute `FileName` takes precedence",
+			configServerRequests: []*configServerRequest{
+				{
+					path:            "/config/some/testing.json",
+					statusCode:      200,
+					responsePayload: `{"some":"json"}`,
+				},
+			},
+			attrib: Attributes{
+				ServerAddress: "http://configserver.localhost",
+				Profile:       "testing",
+				Application:   "some",
+				FileType:      "json",
+				FileName:      "config.json",
+			},
+			wantFiles: map[string]string{"config.json": `{"some":"json"}`},
+		},
+		{
 			name: "When attribute `FileName` defines an unsupported extension then it errors",
 			attrib: Attributes{
 				ServerAddress: "http://configserver.localhost",


### PR DESCRIPTION
Current implementation creates the name of the file to create by concatenating the attributes `application`, `profile` and `fileType`.
Example:
```yaml
application: "myapp"
profile: "prod"
fileType: "json"
```
becomes `myapp-prod.json`.

This is hard for users to grasp. People often are confused and don't know how to reference the file in the filesystem of a container.

This change adds the attribute `fileName` and deprecates the attribute `fileType`.
Users can define the name of the file. However, the extension of the file needs to be supported by Spring Cloud Config Server.
The supported extensions are `.yaml`, `.yml`, `.json` and `.properties`.